### PR TITLE
Support ImportNamespaceSpecifier

### DIFF
--- a/index.js
+++ b/index.js
@@ -63,7 +63,7 @@ module.exports = function (babel) {
                         return;
                     }
                     var firstSpecifier = nodePath.get('specifiers')[0];
-                    if (!firstSpecifier.isImportDefaultSpecifier()) {
+                    if (!(firstSpecifier.isImportDefaultSpecifier() || firstSpecifier.isImportNamespaceSpecifier())) {
                         return;
                     }
                     var local = firstSpecifier.get('local');

--- a/test/fixtures/es6module_namespece/expected.js
+++ b/test/fixtures/es6module_namespece/expected.js
@@ -1,0 +1,10 @@
+'use strict';
+
+import * as assert from 'power-assert';
+
+function add(a, b) {
+    assert(!isNaN(a));
+    assert.equal(typeof b, 'number');
+    assert.ok(!isNaN(b));
+    return a + b;
+}

--- a/test/fixtures/es6module_namespece/fixture.js
+++ b/test/fixtures/es6module_namespece/fixture.js
@@ -1,0 +1,10 @@
+'use strict';
+
+import * as assert from 'assert';
+
+function add (a, b) {
+    assert(!isNaN(a));
+    assert.equal(typeof b, 'number');
+    assert.ok(!isNaN(b));
+    return a + b;
+}

--- a/test/test.js
+++ b/test/test.js
@@ -32,4 +32,5 @@ describe('babel-plugin-empower-assert', function () {
     testTransform('assignment_singlevar');
     testTransform('es6module');
     testTransform('es6module_powerassert');
+    testTransform('es6module_namespece');
 });


### PR DESCRIPTION
fixes #3 

before:

``` javascript
import * as assert from 'assert';

function add (a, b) {
    assert.ok(!isNaN(b));
    return a + b;
}
```

after:

``` javascript
import * as assert from 'power-assert';

function add(a, b) {
    assert.ok(!isNaN(b));
    return a + b;
}
```
